### PR TITLE
prevent screen blinking in urxvt

### DIFF
--- a/pktvisorui.c
+++ b/pktvisorui.c
@@ -261,7 +261,7 @@ void redraw_help() {
 
 void redraw(struct dnsctxt *dns_ctxt) {
 
-    clear();
+    erase();
 
     redraw_header(dns_ctxt);
 


### PR DESCRIPTION
pktvisor UI makes the terminal blink every refresh in urxvt.

This patch resolves the problem.
