### PR TITLE
Support for Maxmind GeoIP2 libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
+sudo: required
 language: c
-compiler:
-  - gcc
-  - clang
+services:
+  - docker
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libgeoip-dev liburcu-dev libpcap-dev libnet1-dev libcli-dev libnl-3-dev libnl-genl-3-dev
+  - docker-compose build .
 
-script: CC=$CC cd src && ./configure && make CC=$CC
+script: 
+  - docker-compose run --rm builder ./configure
+  - docker-compose run --rm builder make
+
 notifications:
   slack:
     secure: kXWHt2FwGzohgwmwDH262R3B359iRmsjPE/wF90ur6/TOfTvxuZicpPOVWsglgDgVP92zMklwgOs941IJmg4VVvqjuvDYeaMB+KLHvxb4Vl0pOg7mLpOXmIVt3NwL3+miSwoQ24XHJb6vGzubeHAjSXpD0N1tVxb792DvHztDTo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 before_install:
-  - docker-compose build .
+  - docker-compose build
 
 script: 
   - docker-compose run --rm builder ./configure

--- a/src/configure
+++ b/src/configure
@@ -265,27 +265,18 @@ EOF
 
 check_libgeoip()
 {
-	echo -n "[*] Checking libGeoIP ... "
+	echo -n "[*] Checking libmaxminddb ... "
 
 	cat > $TMPDIR/geoiptest.c << EOF
-#include <GeoIP.h>
-#include <GeoIPCity.h>
+#include <maxminddb.h>
 
-int main(void)
+void main(void)
 {
-	int dbs[] = {
-		GEOIP_CITY_EDITION_REV1,
-		GEOIP_CITY_EDITION_REV1_V6,
-		GEOIP_COUNTRY_EDITION,
-		GEOIP_COUNTRY_EDITION_V6,
-		GEOIP_ASNUM_EDITION,
-		GEOIP_ASNUM_EDITION_V6,
-	};
-	GeoIP *geoip = GeoIP_new(0);
+	MMDB_strerror(MMDB_FILE_OPEN_ERROR);
 }
 EOF
 
-	$CC -o $TMPDIR/geoiptest $TMPDIR/geoiptest.c -lGeoIP >> config.log 2>&1
+	$CC -o $TMPDIR/geoiptest $TMPDIR/geoiptest.c -lmaxminddb >> config.log 2>&1
 	if [ ! -x $TMPDIR/geoiptest ] ; then
 		echo "[NO]"
 		MISSING_DEFS=1
@@ -622,7 +613,7 @@ if [ -s config.log ] ; then
 	echo "    config.log for details."
 fi
 
-if [ "$HAVE_LIBGEOIP" == "1" -a "$HAVE_LIBZ" == "1"  ] ; then
+if [ "$HAVE_LIBGEOIP" == "1" ] ; then
 	echo "CONFIG_GEOIP=1" >> Config
 else
 	echo "CONFIG_GEOIP=0" >> Config

--- a/src/geoip.conf
+++ b/src/geoip.conf
@@ -1,2 +1,0 @@
-geolite.maxmind.com
-cryptoism.org

--- a/src/geoip.h
+++ b/src/geoip.h
@@ -7,9 +7,8 @@
 #include "config.h"
 #include "die.h"
 
-#if defined(HAVE_GEOIP) && defined(HAVE_LIBZ)
+#if defined(HAVE_GEOIP)
 extern void init_geoip(const char* citydb, const char* asndb);
-extern void update_geoip(void);
 extern int geoip_working(void);
 extern const char *geoip4_city_name(struct sockaddr_in *sa);
 extern const char *geoip6_city_name(struct sockaddr_in6 *sa);
@@ -33,11 +32,6 @@ static inline void init_geoip(int enforce)
 
 static inline void destroy_geoip(void)
 {
-}
-
-static inline void update_geoip(void)
-{
-	panic("No built-in geoip support!\n");
 }
 
 static inline int geoip_working(void)

--- a/src/pktvisor.8
+++ b/src/pktvisor.8
@@ -218,14 +218,6 @@ Only dump packets in hex format to the terminal.
 .SS -l, --ascii
 Only display ASCII printable characters.
 .PP
-.SS -U, --update
-If geographical IP location is used, the built-in database update
-mechanism will be invoked to get Maxmind's latest database. To configure
-search locations for databases, the file /etc/netsniff-ng/geoip.conf contains
-possible addresses. Thus, to save bandwidth or for mirroring of Maxmind's
-databases (to bypass their traffic limit policy), different hosts or IP
-addresses can be placed into geoip.conf, separated by a newline.
-.PP
 .SS -V, --verbose
 Be more verbose during startup i.e. show detailed ring setup information.
 .PP
@@ -330,7 +322,6 @@ functionality:
     * ether.conf - Ethernet type descriptions
     * tcp.conf - TCP port/services map
     * udp.conf - UDP port/services map
-    * geoip.conf - GeoIP database mirrors
 .PP
 .SH FILTER EXAMPLE
 .PP

--- a/src/pktvisor/Makefile
+++ b/src/pktvisor/Makefile
@@ -1,14 +1,14 @@
 pktvisor-libs = $(shell pkg-config --libs libnl-3.0) \
                 $(shell pkg-config --libs libnl-genl-3.0) \
         	    -lpthread \
-		        -lncurses
+		    -lncurses \
+		    -lm
 
 ifeq ($(CONFIG_LIBPCAP), 1)
 pktvisor-libs +=	-lpcap
 endif
 ifeq ($(CONFIG_GEOIP), 1)
-pktvisor-libs +=	-lGeoIP \
-			-lz
+pktvisor-libs +=	-lmaxminddb
 endif
 
 pktvisor-objs =	dissector.o \
@@ -85,5 +85,4 @@ pktvisor-eflags = $(shell pkg-config --cflags libnl-3.0) \
 pktvisor-confs =	ether.conf \
 			tcp.conf \
 			udp.conf \
-			oui.conf \
-			geoip.conf
+			oui.conf


### PR DESCRIPTION
Note that this **replaces** the previous support for their legacy GeoIP product.  It also removes the feature that allowed users to download free Maxmind databases from the web.  This wasn't ported forward mainly because Maxmind no longer offers a free version of the ASN/ISP database; enough code uses ASN that it no longer made sense.

/cc @weyrick 
